### PR TITLE
Improve tests and web UI with new README links

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1,0 +1,39 @@
+# Proxy Hunter
+
+[English Version](README.md) | [中文版はこちら](README.zh-TW.md)
+
+## 概要
+
+Proxy Hunter は、無料プロキシリストサイト [Free Proxy List](https://free-proxy-list.net/) からプロキシを取得し、その有効性をテストする Python ツールです。正規表現を用いて IP アドレスを収集し、[ipify](https://www.ipify.org/) を利用して検証します。開発者やセキュリティアナリストが素早く信頼できるプロキシを得るために役立ちます。
+
+## 特徴
+
+- **無料プロキシの取得**: Free Proxy List から自動でプロキシを取得
+- **プロキシの検証**: 取得したプロキシの接続確認
+- **出力ファイル指定**: 結果を好きなファイルに保存可能
+- **ファイルからの検証**: 指定ファイル内のプロキシを検証
+- **スレッド数設定**: 検証に利用するスレッド数を指定
+- **匿名プロキシフィルタ**: 実 IP を隠すプロキシのみを保持可能
+- **柔軟な出力形式**: テキストまたは JSON 形式で保存
+
+## インストール
+
+```bash
+pip install -r requirements.txt
+```
+
+## 使い方
+
+```bash
+python -m proxyhunter
+```
+
+## ウェブダッシュボード
+
+```bash
+python -m proxyhunter.web_app
+```
+
+## ライセンス
+
+MIT ライセンスの下で配布されています。

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Proxy Hunter
 
-[中文版說明](README.zh-TW.md)
+[中文版說明](README.zh-TW.md) | [日本語はこちら](README.ja.md)
 
 ## Overview
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -1,5 +1,7 @@
 # Proxy Hunter
 
+[English Version](README.md) | [日本語版](README.ja.md)
+
 ## 概覽
 
 Proxy Hunter 是一款強大的 Python 工具，專為從[免費代理列表](https://free-proxy-list.net/)抓取和測試免費代理的可用性而設計。它使用正則表達式來收集 IP 地址列表並利用[ipify](https://www.ipify.org/)測試它們的有效性。對於需要快速且可靠地獲得免費且可工作代理服務器的開發者和安全分析師來說，它是一個必不可少的工具。

--- a/proxyhunter/web_app.py
+++ b/proxyhunter/web_app.py
@@ -58,7 +58,11 @@ INDEX_HTML = """
   <meta charset="utf-8">
   <title>{{ trans.title }}</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css" rel="stylesheet">
+  <link href="https://cdn.datatables.net/1.13.7/css/jquery.dataTables.min.css" rel="stylesheet">
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/jquery@3.7.1/dist/jquery.min.js"></script>
+  <script src="https://cdn.datatables.net/1.13.7/js/jquery.dataTables.min.js"></script>
 </head>
 <body class="p-4">
   <div class="container">
@@ -73,7 +77,7 @@ INDEX_HTML = """
     <p>{{ trans.source }}: <a href="https://free-proxy-list.net/">free-proxy-list.net</a></p>
     <p>{{ trans.total }}: {{ total }} | {{ trans.success }}: {{ success }} | {{ trans.fail }}: {{ fail }} | {{ trans.average }}: {{ average }}</p>
     <canvas id="responseChart" class="mb-4"></canvas>
-    <table class="table table-striped">
+    <table class="table table-striped" id="resultTable">
       <thead>
         <tr>
           <th>{{ trans.proxy }}</th>
@@ -86,7 +90,14 @@ INDEX_HTML = """
       {% for item in results %}
         <tr>
           <td>{{ item.proxy }}</td>
-          <td>{{ item.status }}</td>
+          <td>
+            {% if item.status == 'ok' %}
+              <i class="bi bi-check-circle-fill text-success"></i>
+            {% else %}
+              <i class="bi bi-x-circle-fill text-danger"></i>
+            {% endif %}
+            {{ item.status }}
+          </td>
           <td>{{ item.response_time if item.response_time is not none else '-' }}</td>
           <td>{{ item.data_size }}</td>
         </tr>
@@ -114,6 +125,10 @@ new Chart(ctx, {
       y: { beginAtZero: true }
     }
   }
+});
+
+$(document).ready(function() {
+  $('#resultTable').DataTable();
 });
 </script>
 </body>

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1,5 +1,9 @@
 import json
+import sys
+from pathlib import Path
 from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from proxyhunter.web_app import app
 


### PR DESCRIPTION
## Summary
- add Japanese README
- interlink README files
- modernize web dashboard with Bootstrap icons and DataTables
- fix test import path

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6857e7529bf48325a2c10242b65e287a